### PR TITLE
Separate RevenueCat

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,9 @@
     "react-native-purchases": ">=5.1.0"
   },
   "peerDependenciesMeta": {
-    "react-native-purchases": { "optional": true }
+    "react-native-purchases": {
+      "optional": true
+    }
   },
   "workspaces": [
     "example"

--- a/package.json
+++ b/package.json
@@ -100,6 +100,9 @@
     "react-native": ">=0.71.7",
     "react-native-purchases": ">=5.1.0"
   },
+  "peerDependenciesMeta": {
+    "react-native-purchases": { "optional": true }
+  },
   "workspaces": [
     "example"
   ],

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "react": "18.2.0",
     "react-native": "0.71.7",
     "react-native-builder-bob": "^0.37.0",
+    "react-native-purchases": ">=5.1.0",
     "release-it": "^17.10.0",
     "turbo": "^1.10.7",
     "typescript": "^5.2.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryheliumai/paywall-sdk-react-native",
-  "version": "0.2.16",
+  "version": "0.2.17",
   "description": "Paywall SDK Helium",
   "source": "./src/index.ts",
   "main": "./lib/commonjs/index.js",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,6 @@
     "react": "18.2.0",
     "react-native": "0.71.7",
     "react-native-builder-bob": "^0.37.0",
-    "react-native-purchases": ">=5.1.0",
     "release-it": "^17.10.0",
     "turbo": "^1.10.7",
     "typescript": "^5.2.2"

--- a/src/handlers/revenuecat.ts
+++ b/src/handlers/revenuecat.ts
@@ -1,12 +1,16 @@
 import Purchases, { PURCHASES_ERROR_CODE } from 'react-native-purchases';
-import type { HeliumPurchaseResult, RevenueCatPurchaseConfig } from '../types';
+import type { HeliumPurchaseConfig, HeliumPurchaseResult } from '../types';
 import type { PurchasesError, PurchasesPackage, CustomerInfoUpdateListener, CustomerInfo, PurchasesEntitlementInfo } from 'react-native-purchases';
 
 // Rename the factory function
-export function createRevenueCatPurchaseConfig(config?: { apiKey?: string }): RevenueCatPurchaseConfig {
+export function createRevenueCatPurchaseConfig(config?: {
+  apiKey?: string;
+}): HeliumPurchaseConfig {
+    const rcHandler = new RevenueCatHeliumHandler(config?.apiKey);
     return {
-        type: 'revenuecat',
-        apiKey: config?.apiKey,
+      apiKey: config?.apiKey,
+      makePurchase: rcHandler.makePurchase.bind(rcHandler),
+      restorePurchases: rcHandler.restorePurchases.bind(rcHandler),
     };
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,5 +16,4 @@ export type {
   HeliumTransactionStatus,
   HeliumConfig,
   HeliumUpsellViewProps,
-  CustomPurchaseConfig,
 } from './types';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,20 @@
-export { createRevenueCatPurchaseConfig } from './handlers/revenuecat';
 export { createCustomPurchaseConfig } from './types';
 
-export { HeliumProvider, initialize, presentUpsell, hideUpsell, hideAllUpsells, UpsellView, HELIUM_CTA_NAMES, useHelium, NativeHeliumUpsellView } from './native-interface';
+export {
+  HeliumProvider,
+  initialize,
+  presentUpsell,
+  hideUpsell,
+  hideAllUpsells,
+  UpsellView,
+  HELIUM_CTA_NAMES,
+  useHelium,
+  NativeHeliumUpsellView,
+} from './native-interface';
 
-export type { 
-  HeliumTransactionStatus, 
-  HeliumConfig, 
-  HeliumUpsellViewProps, 
-  RevenueCatPurchaseConfig, 
-  CustomPurchaseConfig
-} from './types'; 
+export type {
+  HeliumTransactionStatus,
+  HeliumConfig,
+  HeliumUpsellViewProps,
+  CustomPurchaseConfig,
+} from './types';

--- a/src/native-interface.tsx
+++ b/src/native-interface.tsx
@@ -1,6 +1,6 @@
 import { findNodeHandle, NativeModules, View, NativeEventEmitter, requireNativeComponent } from 'react-native';
 import React, { createRef, useEffect, useState, createContext, useContext } from 'react';
-import type { HeliumConfig, HeliumUpsellViewProps, HeliumDownloadStatus, HeliumPurchaseResult } from './types';
+import type { HeliumConfig, HeliumUpsellViewProps, HeliumDownloadStatus } from './types';
 
 const { HeliumBridge } = NativeModules;
 const heliumEventEmitter = new NativeEventEmitter(HeliumBridge);

--- a/src/revenuecat.ts
+++ b/src/revenuecat.ts
@@ -1,0 +1,1 @@
+export { createRevenueCatPurchaseConfig } from './handlers/revenuecat';

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,32 +8,21 @@ export type HeliumDownloadStatus = 'success' | 'failed' | 'inProgress' | 'notSta
 // --- Purchase Configuration Types ---
 
 /** Interface for providing custom purchase handling logic. */
-export interface CustomPurchaseConfig {
+
+export interface HeliumPurchaseConfig {
   makePurchase: (productId: string) => Promise<HeliumPurchaseResult>;
   restorePurchases: () => Promise<boolean>;
-  /** Discriminant property to identify custom callbacks */
-  type: 'custom';
-}
 
-/** Configuration for using the built-in RevenueCat handler. */
-export interface RevenueCatPurchaseConfig {
   /** Optional RevenueCat API Key. If not provided, RevenueCat must be configured elsewhere. */
   apiKey?: string;
-   /** Discriminant property to identify RevenueCat config */
-  type: 'revenuecat';
 }
-
-// Union type for the purchase configuration
-export type HeliumPurchaseConfig = CustomPurchaseConfig | RevenueCatPurchaseConfig;
-// Add other config types here in the future, e.g. | StripePurchaseConfig
 
 // Helper function for creating Custom Purchase Config
 export function createCustomPurchaseConfig(callbacks: {
   makePurchase: (productId: string) => Promise<HeliumPurchaseResult>;
   restorePurchases: () => Promise<boolean>;
-}): CustomPurchaseConfig {
+}): HeliumPurchaseConfig {
   return {
-    type: 'custom',
     makePurchase: callbacks.makePurchase,
     restorePurchases: callbacks.restorePurchases,
   };
@@ -54,6 +43,7 @@ export interface HeliumConfig {
   customUserId?: string;
   customAPIEndpoint?: string;
   customUserTraits?: Record<string, any>;
+  revenueCatAppUserId?: string;
 }
 
 // --- Other Existing Types ---

--- a/yarn.lock
+++ b/yarn.lock
@@ -3727,6 +3727,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@revenuecat/purchases-typescript-internal@npm:13.37.0":
+  version: 13.37.0
+  resolution: "@revenuecat/purchases-typescript-internal@npm:13.37.0"
+  checksum: 6a0361eb52d0b310ea42b4d164deb3806a563e1f92a3a5e0a0de32d4bee6368a20f867b0d74be67c93a6cd7f1657987c03db9b197d72f326e094eb5e582f1abf
+  languageName: node
+  linkType: hard
+
 "@rnx-kit/chromium-edge-launcher@npm:^1.0.0":
   version: 1.0.0
   resolution: "@rnx-kit/chromium-edge-launcher@npm:1.0.0"
@@ -3823,6 +3830,7 @@ __metadata:
     react: 18.2.0
     react-native: 0.71.7
     react-native-builder-bob: ^0.37.0
+    react-native-purchases: ">=5.1.0"
     release-it: ^17.10.0
     turbo: ^1.10.7
     typescript: ^5.2.2
@@ -12360,6 +12368,18 @@ __metadata:
   version: 0.71.19
   resolution: "react-native-gradle-plugin@npm:0.71.19"
   checksum: 2e3ab679f0b81edd81b9fb88a73a16c8b9b6dbef4e7158fd894c42e6dff04ba8d11f1b9663ffa2c30d0d9deee3cd44b033cd280322c010be3c290e4422088a7a
+  languageName: node
+  linkType: hard
+
+"react-native-purchases@npm:>=5.1.0":
+  version: 8.11.6
+  resolution: "react-native-purchases@npm:8.11.6"
+  dependencies:
+    "@revenuecat/purchases-typescript-internal": 13.37.0
+  peerDependencies:
+    react: ">= 16.6.3"
+    react-native: "*"
+  checksum: e22e5793d928781e5b0135eabf08898cd92c96dc2f7266c2143abb081e55175ef077d5936e42f2feb1aa0cd6acb9c8b4cad483da1776d946d3a304a7c30e23ce
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3727,13 +3727,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@revenuecat/purchases-typescript-internal@npm:13.29.1":
-  version: 13.29.1
-  resolution: "@revenuecat/purchases-typescript-internal@npm:13.29.1"
-  checksum: eda5cefc84897b17f9c831e58db02adb65bfaa4699735da13d90e28a66864ae341934fde16ad6ea7793e0aee51a62eb59fb3d5440286f2fded90ae9ce19d663c
-  languageName: node
-  linkType: hard
-
 "@rnx-kit/chromium-edge-launcher@npm:^1.0.0":
   version: 1.0.0
   resolution: "@rnx-kit/chromium-edge-launcher@npm:1.0.0"
@@ -3830,7 +3823,6 @@ __metadata:
     react: 18.2.0
     react-native: 0.71.7
     react-native-builder-bob: ^0.37.0
-    react-native-purchases: ">=5.1.0"
     release-it: ^17.10.0
     turbo: ^1.10.7
     typescript: ^5.2.2
@@ -3838,6 +3830,9 @@ __metadata:
     react: ">=18.2.0"
     react-native: ">=0.71.7"
     react-native-purchases: ">=5.1.0"
+  peerDependenciesMeta:
+    react-native-purchases:
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -12365,18 +12360,6 @@ __metadata:
   version: 0.71.19
   resolution: "react-native-gradle-plugin@npm:0.71.19"
   checksum: 2e3ab679f0b81edd81b9fb88a73a16c8b9b6dbef4e7158fd894c42e6dff04ba8d11f1b9663ffa2c30d0d9deee3cd44b033cd280322c010be3c290e4422088a7a
-  languageName: node
-  linkType: hard
-
-"react-native-purchases@npm:>=5.1.0":
-  version: 8.9.6
-  resolution: "react-native-purchases@npm:8.9.6"
-  dependencies:
-    "@revenuecat/purchases-typescript-internal": 13.29.1
-  peerDependencies:
-    react: ">= 16.6.3"
-    react-native: "*"
-  checksum: 238cc882853e861cabe3ed80f697a43a9fac14270d1e68a10fa7e51b4f69402b6ca77f9524a11a4ffe93026ea366a54143e9dd39cc8f853a2027662d746c0335
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Extract RevenueCat so that non-RC users do not need to include as dependency.

For existing RevenueCat users, the import has changed for createRevenueCatPurchaseConfig:
`import {createRevenueCatPurchaseConfig} from "@tryheliumai/paywall-sdk-react-native/src/handlers/revenuecat";`

And it is highly recommended to now pass in RevenueCat app user ID during Helium `initialize` for better paywall analytics.
`revenueCatAppUserId: await Purchases.getAppUserID()`