### PR TITLE
Hel 4363 safer ios bridging

### DIFF
--- a/ios/HeliumSwiftInterface.swift
+++ b/ios/HeliumSwiftInterface.swift
@@ -333,9 +333,8 @@ class HeliumBridge: RCTEventEmitter {
             }
         }
 
-        // todo pass in extracted version
-//         let wrapperSdkVersion = config["wrapperSdkVersion"] as? String ?? "unknown"
-        HeliumSdkConfig.shared.setWrapperSdkInfo(sdk: "old-expo", version: "3.0.20")
+        let wrapperSdkVersion = config["wrapperSdkVersion"] as? String ?? "unknown"
+        HeliumSdkConfig.shared.setWrapperSdkInfo(sdk: "old-expo", version: wrapperSdkVersion)
 
         Helium.shared.initialize(
             apiKey: apiKey,

--- a/ios/HeliumSwiftInterface.swift
+++ b/ios/HeliumSwiftInterface.swift
@@ -79,7 +79,7 @@ private class PurchaseStateManager {
 
     // Configuration
     private let maxQueuedEvents = 30
-    private let eventExpirationSeconds: TimeInterval = 30.0
+    private let eventExpirationSeconds: TimeInterval = 10.0
 
     // Event queue
     private struct PendingEvent {
@@ -99,6 +99,13 @@ private class PurchaseStateManager {
             pendingEvents.removeFirst()
         }
         pendingEvents.append(PendingEvent(eventName: eventName, eventData: eventData, timestamp: Date()))
+    }
+
+    // Clear all pending events
+    func clearPendingEvents() {
+        eventLock.lock()
+        pendingEvents.removeAll()
+        eventLock.unlock()
     }
 
     // Flush queued events to bridge
@@ -536,6 +543,7 @@ class HeliumBridge: RCTEventEmitter {
 
   @objc
   public func resetHelium() {
+      PurchaseStateManager.shared.clearPendingEvents()
       Helium.resetHelium()
   }
 

--- a/ios/ObjCExceptionCatcher.h
+++ b/ios/ObjCExceptionCatcher.h
@@ -1,0 +1,9 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ObjCExceptionCatcher : NSObject
++ (BOOL)execute:(void(NS_NOESCAPE ^)(void))block;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/ObjCExceptionCatcher.m
+++ b/ios/ObjCExceptionCatcher.m
@@ -1,0 +1,16 @@
+#import "ObjCExceptionCatcher.h"
+
+@implementation ObjCExceptionCatcher
+
++ (BOOL)execute:(void(NS_NOESCAPE ^)(void))block {
+    @try {
+        block();
+        return YES;
+    }
+    @catch (NSException *exception) {
+        NSLog(@"[HeliumPaywallSdk] Caught NSException: %@ - %@", exception.name, exception.reason);
+        return NO;
+    }
+}
+
+@end

--- a/ios/PaywallSdkReactNative-Bridging-Header.h
+++ b/ios/PaywallSdkReactNative-Bridging-Header.h
@@ -1,2 +1,3 @@
 #import <React/RCTBridgeModule.h>
 #import <React/RCTViewManager.h>
+#import "ObjCExceptionCatcher.h"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryheliumai/paywall-sdk-react-native",
-  "version": "3.0.20",
+  "version": "3.0.21",
   "description": "Paywall SDK Helium",
   "source": "./src/index.ts",
   "main": "./lib/commonjs/index.js",

--- a/src/native-interface.tsx
+++ b/src/native-interface.tsx
@@ -16,6 +16,13 @@ import type {
 import type { ExperimentInfo } from './HeliumExperimentInfo.types';
 
 const { HeliumBridge } = NativeModules;
+
+let SDK_VERSION = 'unknown';
+try {
+  SDK_VERSION = require('../package.json').version;
+} catch {
+  // package.json can't be loaded, accept that we won't get wrapper sdk version
+}
 const heliumEventEmitter = new NativeEventEmitter(HeliumBridge);
 
 // Register the native component once at module level
@@ -148,6 +155,7 @@ export const initialize = async (config: HeliumConfig) => {
         config.paywallLoadingConfig
       ),
       useDefaultDelegate: !config.purchaseConfig,
+      wrapperSdkVersion: SDK_VERSION,
     },
     {}
   );

--- a/src/native-interface.tsx
+++ b/src/native-interface.tsx
@@ -70,7 +70,7 @@ export const initialize = async (config: HeliumConfig) => {
       handlePaywallEvent(event);
 
       // Forward all events to the callback provided in config
-      config.onHeliumPaywallEvent(event);
+      config.onHeliumPaywallEvent?.(event);
     }
   );
 

--- a/src/native-interface.tsx
+++ b/src/native-interface.tsx
@@ -19,7 +19,7 @@ const { HeliumBridge } = NativeModules;
 
 let SDK_VERSION = 'unknown';
 try {
-  SDK_VERSION = require('../package.json').version;
+  SDK_VERSION = require('@tryheliumai/paywall-sdk-react-native/package.json').version;
 } catch {
   // package.json can't be loaded, accept that we won't get wrapper sdk version
 }

--- a/src/native-interface.tsx
+++ b/src/native-interface.tsx
@@ -45,6 +45,7 @@ export const initialize = async (config: HeliumConfig) => {
     console.log('[Helium] Already initialized, skipping...');
     return;
   }
+  isInitialized = true;
 
   const purchaseHandler = config.purchaseConfig
     ? {
@@ -159,9 +160,6 @@ export const initialize = async (config: HeliumConfig) => {
     },
     {}
   );
-
-  // Mark as initialized after successful initialization
-  isInitialized = true;
 };
 
 let paywallEventHandlers: PaywallEventHandlers | undefined;

--- a/src/types.ts
+++ b/src/types.ts
@@ -205,7 +205,7 @@ export interface HeliumConfig {
    */
   purchaseConfig?: HeliumPurchaseConfig;
   /** Callback for receiving all Helium paywall events. */
-  onHeliumPaywallEvent: (event: HeliumPaywallEvent) => void;
+  onHeliumPaywallEvent?: (event: HeliumPaywallEvent) => void;
 
   // Optional configurations
   /** Fallback bundle in the rare situation that paywall is not ready to be shown. Highly recommended. See docs at https://docs.tryhelium.com/guides/fallback-bundle#react-native */


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how iOS-to-RN events are emitted (queuing, retry, exception catching) and tweaks initialization semantics, which can affect purchase/paywall flows if ordering or delivery behavior differs from before.
> 
> **Overview**
> Improves iOS React Native bridging robustness by routing all `sendEvent` calls through a new `safeSendEvent` path that catches Objective-C exceptions and **queues events** when the bridge is unavailable or event dispatch fails, then flushes them on `initialize`/`presentUpsell` (dropping stale items and bounding queue size). Adds `ObjCExceptionCatcher` (and bridging header import) plus clears queued events on `resetHelium`.
> 
> Updates wrapper SDK version reporting by passing the JS package version into native (`wrapperSdkVersion`) instead of a hardcoded value, makes `onHeliumPaywallEvent` optional (and uses optional chaining), sets `isInitialized` earlier to avoid double-init, and bumps the package version to `3.0.21`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 52708f7388dabb25f1762733696eb85bbef077fa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic event queuing, expiry, and retry for more reliable event delivery.
  * Propagates wrapper SDK version to the native bridge.
  * Download status tracking for paywall downloads.

* **Bug Fixes**
  * Improved error handling and native exception catching for greater stability.
  * Ensures queued events are flushed when bridge or upsell is set.

* **Chores**
  * Bumped package version to 3.0.21.
  * Made paywall event callback optional.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->