### PR TITLE
empty api key safety; refactoring and more misc cleanup

### DIFF
--- a/android/src/main/java/com/paywallsdkreactnative/HeliumBridge.kt
+++ b/android/src/main/java/com/paywallsdkreactnative/HeliumBridge.kt
@@ -92,12 +92,7 @@ private object BridgeStateManager {
                 return@forEach
             }
             if (!bridge.sendEvent(event.eventName, event.eventData)) {
-                // Failed to emit — re-queue
-                synchronized(pendingEvents) {
-                    if (pendingEvents.size < MAX_QUEUED_EVENTS) {
-                        pendingEvents.add(event)
-                    }
-                }
+                Log.w(TAG, "Failed to flush event ${event.eventName}, dropping")
             }
         }
     }
@@ -179,10 +174,14 @@ class HeliumBridge(private val reactContext: ReactApplicationContext) :
 
     @ReactMethod
     fun initialize(config: ReadableMap) {
+        val apiKey = config.getString("apiKey")
+        if (apiKey.isNullOrEmpty()) {
+            Log.e(TAG, "initialize called with missing/empty apiKey; aborting.")
+            return
+        }
+
         BridgeStateManager.currentBridge = this
         BridgeStateManager.flushEvents(this)
-
-        val apiKey = config.getString("apiKey") ?: return
         val customUserId = if (config.hasKey("customUserId")) config.getString("customUserId") else null
         val customAPIEndpoint = if (config.hasKey("customAPIEndpoint")) config.getString("customAPIEndpoint") else null
         val revenueCatAppUserId = if (config.hasKey("revenueCatAppUserId")) config.getString("revenueCatAppUserId") else null
@@ -362,7 +361,7 @@ class HeliumBridge(private val reactContext: ReactApplicationContext) :
         val continuation = BridgeStateManager.purchaseContinuation ?: return
 
         val status: HeliumPaywallTransactionStatus = when (statusString.lowercase()) {
-            "completed", "purchased" -> HeliumPaywallTransactionStatus.Purchased
+            "purchased" -> HeliumPaywallTransactionStatus.Purchased
             "cancelled" -> HeliumPaywallTransactionStatus.Cancelled
             "restored" -> HeliumPaywallTransactionStatus.Purchased  // Android SDK has no Restored, map to Purchased
             "pending" -> HeliumPaywallTransactionStatus.Pending

--- a/ios/HeliumSwiftInterface.swift
+++ b/ios/HeliumSwiftInterface.swift
@@ -160,12 +160,13 @@ class HeliumBridge: RCTEventEmitter {
 
     @objc
     public func initialize(_ config: NSDictionary) {
-        PurchaseStateManager.shared.currentBridge = self
-        PurchaseStateManager.shared.flushEvents(bridge: self)
-
-        guard let apiKey = config["apiKey"] as? String else {
+        guard let apiKey = config["apiKey"] as? String, !apiKey.isEmpty else {
+            print("[Helium] initialize called with missing/empty apiKey; aborting.")
             return
         }
+
+        PurchaseStateManager.shared.currentBridge = self
+        PurchaseStateManager.shared.flushEvents(bridge: self)
 
         let customUserId = config["customUserId"] as? String
         let customAPIEndpoint = config["customAPIEndpoint"] as? String
@@ -288,7 +289,7 @@ class HeliumBridge: RCTEventEmitter {
         let status: HeliumPaywallTransactionStatus
 
         switch lowercasedStatus {
-        case "purchased", "completed":
+        case "purchased":
             status = .purchased
             if let productId = productId as String?, let transactionId = transactionId as String? {
                 PurchaseStateManager.shared.latestTransactionResult = HeliumTransactionIdResult(

--- a/src/native-interface.tsx
+++ b/src/native-interface.tsx
@@ -27,6 +27,10 @@ const heliumEventEmitter = new NativeEventEmitter(HeliumBridge);
 
 let isInitialized = false;
 
+export const getDownloadStatus = async (): Promise<HeliumDownloadStatus> => {
+  return HeliumBridge.getDownloadStatus();
+};
+
 const HELIUM_EVENT_NAMES = [
   'onHeliumPaywallEvent',
   'onDelegateActionEvent',
@@ -39,10 +43,6 @@ const removeAllHeliumListeners = () => {
   for (const name of HELIUM_EVENT_NAMES) {
     heliumEventEmitter.removeAllListeners(name);
   }
-};
-
-export const getDownloadStatus = async (): Promise<HeliumDownloadStatus> => {
-  return HeliumBridge.getDownloadStatus();
 };
 
 function setupEventListeners(config: HeliumConfig) {
@@ -200,6 +200,10 @@ const buildNativeConfig = async (
 
 export const initialize = async (config: HeliumConfig) => {
   if (isInitialized) return;
+  if (!config.apiKey) {
+    console.error('[Helium] initialize called without an apiKey; aborting.');
+    return;
+  }
   isInitialized = true;
   try {
     setupEventListeners(config);

--- a/src/native-interface.tsx
+++ b/src/native-interface.tsx
@@ -41,7 +41,11 @@ const HELIUM_EVENT_NAMES = [
 
 const removeAllHeliumListeners = () => {
   for (const name of HELIUM_EVENT_NAMES) {
-    heliumEventEmitter.removeAllListeners(name);
+    try {
+      heliumEventEmitter.removeAllListeners(name);
+    } catch (e) {
+      console.warn(`[Helium] Failed to remove listeners for ${name}:`, e);
+    }
   }
 };
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes initialization gating and event/purchase status handling across JS, Android, and iOS, which could affect whether the SDK initializes or whether queued events/purchase results are processed as before.
> 
> **Overview**
> Adds **defensive initialization** across JS, Android, and iOS: `initialize` now aborts (with logging) when `apiKey` is missing/empty, avoiding partial setup.
> 
> Adjusts **bridge reliability behavior** by making JS listener cleanup resilient to emitter errors, and changing Android’s queued-event flush to *drop* events that fail to emit instead of re-queuing them.
> 
> Tightens **purchase result parsing** on both platforms by no longer treating `"completed"` as a successful purchase status (only `"purchased"` maps to success).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 962d2854f719a4b1edd5b87c2eb2dea09258c8a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->