### PR TITLE
use locks for safer thread safety with purchase/restore continuations

### DIFF
--- a/android/src/main/java/com/paywallsdkreactnative/HeliumBridge.kt
+++ b/android/src/main/java/com/paywallsdkreactnative/HeliumBridge.kt
@@ -42,9 +42,17 @@ private object BridgeStateManager {
     private const val MAX_QUEUED_EVENTS = 30
     private const val EVENT_EXPIRATION_MS = 30_000L
 
+    // Guards the active purchase/restore continuations against cross-thread races between
+    // the RN module thread (handlePurchaseResult) and the Helium SDK coroutine dispatcher
+    // (makePurchase).
+    private val continuationLock = Any()
+    private var _purchaseContinuation: ((HeliumPaywallTransactionStatus) -> Unit)? = null
+    private var _restoreContinuation: ((Boolean) -> Unit)? = null
+
+    // Written on the RN module thread; read from background threads (Helium log listener,
+    // SDK coroutine dispatcher). @Volatile ensures cross-thread visibility of the reference.
+    @Volatile
     var currentBridge: HeliumBridge? = null
-    var purchaseContinuation: ((HeliumPaywallTransactionStatus) -> Unit)? = null
-    var restoreContinuation: ((Boolean) -> Unit)? = null
 
     private data class PendingEvent(
         val eventName: String,
@@ -53,12 +61,52 @@ private object BridgeStateManager {
     )
     private val pendingEvents = mutableListOf<PendingEvent>()
 
-    fun clearPurchase() {
-        purchaseContinuation = null
+    fun setPurchaseContinuation(continuation: (HeliumPaywallTransactionStatus) -> Unit) {
+        val orphan = synchronized(continuationLock) {
+            val existing = _purchaseContinuation
+            _purchaseContinuation = continuation
+            existing
+        }
+        orphan?.invoke(HeliumPaywallTransactionStatus.Cancelled)
     }
 
-    fun clearRestore() {
-        restoreContinuation = null
+    fun takePurchaseContinuation(): ((HeliumPaywallTransactionStatus) -> Unit)? = synchronized(continuationLock) {
+        val c = _purchaseContinuation
+        _purchaseContinuation = null
+        c
+    }
+
+    // Cancellation handler clears only its own continuation — a later setPurchaseContinuation
+    // could already have replaced the stored value, and we must not wipe that newer one.
+    fun clearPurchaseContinuationIf(expected: (HeliumPaywallTransactionStatus) -> Unit) {
+        synchronized(continuationLock) {
+            if (_purchaseContinuation === expected) {
+                _purchaseContinuation = null
+            }
+        }
+    }
+
+    fun setRestoreContinuation(continuation: (Boolean) -> Unit) {
+        val orphan = synchronized(continuationLock) {
+            val existing = _restoreContinuation
+            _restoreContinuation = continuation
+            existing
+        }
+        orphan?.invoke(false)
+    }
+
+    fun takeRestoreContinuation(): ((Boolean) -> Unit)? = synchronized(continuationLock) {
+        val c = _restoreContinuation
+        _restoreContinuation = null
+        c
+    }
+
+    fun clearRestoreContinuationIf(expected: (Boolean) -> Unit) {
+        synchronized(continuationLock) {
+            if (_restoreContinuation === expected) {
+                _restoreContinuation = null
+            }
+        }
     }
 
     private fun queueEvent(eventName: String, eventData: Map<String, Any?>) {
@@ -358,7 +406,11 @@ class HeliumBridge(private val reactContext: ReactApplicationContext) :
         originalTransactionId: String?,
         productId: String?
     ) {
-        val continuation = BridgeStateManager.purchaseContinuation ?: return
+        val continuation = BridgeStateManager.takePurchaseContinuation()
+        if (continuation == null) {
+            Log.w(TAG, "handlePurchaseResult called with no active continuation")
+            return
+        }
 
         val status: HeliumPaywallTransactionStatus = when (statusString.lowercase()) {
             "purchased" -> HeliumPaywallTransactionStatus.Purchased
@@ -373,17 +425,16 @@ class HeliumBridge(private val reactContext: ReactApplicationContext) :
             )
         }
 
-        // TODO: forward transactionId / originalTransactionId / productId to
-        // Helium analytics once the Helium Android SDK exposes an API for it.
-
-        BridgeStateManager.clearPurchase()
         continuation(status)
     }
 
     @ReactMethod
     fun handleRestoreResult(success: Boolean) {
-        val continuation = BridgeStateManager.restoreContinuation ?: return
-        BridgeStateManager.clearRestore()
+        val continuation = BridgeStateManager.takeRestoreContinuation()
+        if (continuation == null) {
+            Log.w(TAG, "handleRestoreResult called with no active continuation")
+            return
+        }
         continuation(success)
     }
 
@@ -737,17 +788,13 @@ private class CustomPaywallDelegate(
         offerId: String?
     ): HeliumPaywallTransactionStatus {
         return suspendCancellableCoroutine { continuation ->
-            BridgeStateManager.purchaseContinuation?.let { existing ->
-                existing(HeliumPaywallTransactionStatus.Cancelled)
-                BridgeStateManager.clearPurchase()
-            }
-
-            BridgeStateManager.purchaseContinuation = { status ->
+            val resumeCallback: (HeliumPaywallTransactionStatus) -> Unit = { status ->
                 continuation.resume(status)
             }
+            BridgeStateManager.setPurchaseContinuation(resumeCallback)
 
             continuation.invokeOnCancellation {
-                BridgeStateManager.clearPurchase()
+                BridgeStateManager.clearPurchaseContinuationIf(resumeCallback)
             }
 
             val eventMap = mutableMapOf<String, Any?>(
@@ -763,17 +810,13 @@ private class CustomPaywallDelegate(
 
     override suspend fun restorePurchases(): Boolean {
         return suspendCancellableCoroutine { continuation ->
-            BridgeStateManager.restoreContinuation?.let { existing ->
-                existing(false)
-                BridgeStateManager.clearRestore()
-            }
-
-            BridgeStateManager.restoreContinuation = { success ->
+            val resumeCallback: (Boolean) -> Unit = { success ->
                 continuation.resume(success)
             }
+            BridgeStateManager.setRestoreContinuation(resumeCallback)
 
             continuation.invokeOnCancellation {
-                BridgeStateManager.clearRestore()
+                BridgeStateManager.clearRestoreContinuationIf(resumeCallback)
             }
 
             BridgeStateManager.safeSendEvent(

--- a/ios/HeliumSwiftInterface.swift
+++ b/ios/HeliumSwiftInterface.swift
@@ -31,8 +31,12 @@ private class PurchaseStateManager {
 
     var currentBridge: HeliumBridge?
 
-    var activePurchaseContinuation: CheckedContinuation<HeliumPaywallTransactionStatus, Never>?
-    var activeRestoreContinuation: CheckedContinuation<Bool, Never>?
+    // Guards the active purchase/restore continuations against cross-thread races between
+    // the RN bridge methodQueue (handlePurchaseResult) and the Swift-concurrency executor
+    // (makePurchase). Without it, both sides can double-resume and CheckedContinuation traps.
+    private let continuationLock = NSLock()
+    private var _activePurchaseContinuation: CheckedContinuation<HeliumPaywallTransactionStatus, Never>?
+    private var _activeRestoreContinuation: CheckedContinuation<Bool, Never>?
 
     private var _latestTransactionResult: HeliumTransactionIdResult?
     private let transactionResultLock = NSLock()
@@ -53,12 +57,36 @@ private class PurchaseStateManager {
 
     private init() {}
 
-    func clearPurchase() {
-        activePurchaseContinuation = nil
+    func setPurchaseContinuation(_ continuation: CheckedContinuation<HeliumPaywallTransactionStatus, Never>) {
+        continuationLock.lock()
+        let orphan = _activePurchaseContinuation
+        _activePurchaseContinuation = continuation
+        continuationLock.unlock()
+        orphan?.resume(returning: .cancelled)
     }
 
-    func clearRestore() {
-        activeRestoreContinuation = nil
+    func takePurchaseContinuation() -> CheckedContinuation<HeliumPaywallTransactionStatus, Never>? {
+        continuationLock.lock()
+        defer { continuationLock.unlock() }
+        let continuation = _activePurchaseContinuation
+        _activePurchaseContinuation = nil
+        return continuation
+    }
+
+    func setRestoreContinuation(_ continuation: CheckedContinuation<Bool, Never>) {
+        continuationLock.lock()
+        let orphan = _activeRestoreContinuation
+        _activeRestoreContinuation = continuation
+        continuationLock.unlock()
+        orphan?.resume(returning: false)
+    }
+
+    func takeRestoreContinuation() -> CheckedContinuation<Bool, Never>? {
+        continuationLock.lock()
+        defer { continuationLock.unlock() }
+        let continuation = _activeRestoreContinuation
+        _activeRestoreContinuation = nil
+        return continuation
     }
 
     // MARK: - Event Queuing
@@ -280,7 +308,7 @@ class HeliumBridge: RCTEventEmitter {
         originalTransactionId: NSString?,
         productId: NSString?
     ) {
-        guard let continuation = PurchaseStateManager.shared.activePurchaseContinuation else {
+        guard let continuation = PurchaseStateManager.shared.takePurchaseContinuation() else {
             print("[Helium] handlePurchaseResult called with no active continuation")
             return
         }
@@ -310,17 +338,15 @@ class HeliumBridge: RCTEventEmitter {
             status = .failed(PurchaseError.unknownStatus(status: lowercasedStatus))
         }
 
-        PurchaseStateManager.shared.clearPurchase()
         continuation.resume(returning: status)
     }
 
     @objc
     public func handleRestoreResult(_ success: Bool) {
-        guard let continuation = PurchaseStateManager.shared.activeRestoreContinuation else {
+        guard let continuation = PurchaseStateManager.shared.takeRestoreContinuation() else {
             print("[Helium] handleRestoreResult called with no active continuation")
             return
         }
-        PurchaseStateManager.shared.clearRestore()
         continuation.resume(returning: success)
     }
 
@@ -591,13 +617,8 @@ private class InternalDelegate: HeliumPaywallDelegate, HeliumDelegateReturnsTran
     public func makePurchase(productId: String) async -> HeliumPaywallTransactionStatus {
         PurchaseStateManager.shared.latestTransactionResult = nil
 
-        if let existing = PurchaseStateManager.shared.activePurchaseContinuation {
-            existing.resume(returning: .cancelled)
-            PurchaseStateManager.shared.clearPurchase()
-        }
-
         return await withCheckedContinuation { continuation in
-            PurchaseStateManager.shared.activePurchaseContinuation = continuation
+            PurchaseStateManager.shared.setPurchaseContinuation(continuation)
 
             PurchaseStateManager.shared.safeSendEvent(
                 eventName: "onDelegateActionEvent",
@@ -610,13 +631,8 @@ private class InternalDelegate: HeliumPaywallDelegate, HeliumDelegateReturnsTran
     }
 
     public func restorePurchases() async -> Bool {
-        if let existing = PurchaseStateManager.shared.activeRestoreContinuation {
-            existing.resume(returning: false)
-            PurchaseStateManager.shared.clearRestore()
-        }
-
         return await withCheckedContinuation { continuation in
-            PurchaseStateManager.shared.activeRestoreContinuation = continuation
+            PurchaseStateManager.shared.setRestoreContinuation(continuation)
 
             PurchaseStateManager.shared.safeSendEvent(
                 eventName: "onDelegateActionEvent",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches purchase/restore bridging on both Android and iOS; concurrency/locking changes can affect transaction completion paths and are hard to test exhaustively, but scope is limited to continuation management.
> 
> **Overview**
> Improves thread-safety of the React Native purchase/restore bridge on **Android and iOS** by guarding active continuations with locks and making completion a single-consumer `take*Continuation()` operation.
> 
> Replaces ad-hoc clearing with safe set/take/conditional-clear helpers, cancels any orphaned in-flight continuation when a new one starts, and adds warnings when result handlers are invoked without an active continuation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f47c32689be41075b6ba6ea488c1778e0568f730. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced internal stability and resource management for purchase and restore operations across Android and iOS platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->