### PR TITLE
[HEL-5184] | RevenueCat delegate updates

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -40,7 +40,7 @@
         "react": "18.2.0",
         "react-native": "0.71.7",
         "react-native-builder-bob": "^0.37.0",
-        "react-native-purchases": ">=5.1.0",
+        "react-native-purchases": ">=8.0.0",
         "turbo": "^1.10.7",
         "typescript": "^5.2.2"
       },
@@ -48,7 +48,7 @@
         "expo-file-system": "*",
         "react": ">=18.2.0",
         "react-native": ">=0.71.7",
-        "react-native-purchases": ">=5.1.0"
+        "react-native-purchases": ">=8.0.0"
       },
       "peerDependenciesMeta": {
         "expo-file-system": {

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "react": "18.2.0",
     "react-native": "0.71.7",
     "react-native-builder-bob": "^0.37.0",
-    "react-native-purchases": ">=5.1.0",
+    "react-native-purchases": ">=8.0.0",
     "turbo": "^1.10.7",
     "typescript": "^5.2.2"
   },
@@ -94,7 +94,7 @@
     "expo-file-system": "*",
     "react": ">=18.2.0",
     "react-native": ">=0.71.7",
-    "react-native-purchases": ">=5.1.0"
+    "react-native-purchases": ">=8.0.0"
   },
   "peerDependenciesMeta": {
     "expo-file-system": {

--- a/src/__tests__/revenuecat.test.ts
+++ b/src/__tests__/revenuecat.test.ts
@@ -1,0 +1,255 @@
+import Purchases, { PURCHASES_ERROR_CODE } from 'react-native-purchases';
+import type { CustomerInfo, PurchasesStoreProduct } from 'react-native-purchases';
+import { createRevenueCatPurchaseConfig } from '../handlers/revenuecat';
+import { setRevenueCatAppUserId } from '../native-interface';
+
+jest.mock('../native-interface', () => ({
+  setRevenueCatAppUserId: jest.fn(),
+}));
+
+jest.mock('react-native-purchases', () => ({
+  __esModule: true,
+  default: {
+    isConfigured: jest.fn(),
+    configure: jest.fn(),
+    getAppUserID: jest.fn(),
+    getProducts: jest.fn(),
+    purchaseStoreProduct: jest.fn(),
+    purchaseSubscriptionOption: jest.fn(),
+    restorePurchases: jest.fn(),
+  },
+  PURCHASES_ERROR_CODE: {
+    PURCHASE_CANCELLED_ERROR: '1',
+    STORE_PROBLEM_ERROR: '2',
+    MISSING_RECEIPT_FILE_ERROR: '9',
+    NETWORK_ERROR: '10',
+    UNKNOWN_BACKEND_ERROR: '16',
+    PAYMENT_PENDING_ERROR: '20',
+  },
+  PRODUCT_CATEGORY: {
+    NON_SUBSCRIPTION: 'NON_SUBSCRIPTION',
+    SUBSCRIPTION: 'SUBSCRIPTION',
+  },
+}));
+
+const mockPurchases = jest.mocked(Purchases);
+
+const product = (identifier: string, subscriptionOptions?: Array<{ id: string }>) =>
+  ({ identifier, subscriptionOptions }) as unknown as PurchasesStoreProduct;
+
+const activeCustomerInfo = (productId: string) =>
+  ({
+    entitlements: { active: { premium: { productIdentifier: productId } } },
+    activeSubscriptions: [productId],
+    allPurchasedProductIdentifiers: [productId],
+  }) as unknown as CustomerInfo;
+
+const purchaseResult = (productId: string, transactionId?: string) =>
+  ({
+    customerInfo: activeCustomerInfo(productId),
+    transaction: transactionId ? { transactionIdentifier: transactionId } : undefined,
+  }) as never;
+
+const rcError = (code: string, underlyingErrorMessage?: string) =>
+  Object.assign(new Error('rc failure'), { code, underlyingErrorMessage });
+
+const flushMicrotasks = () => new Promise((resolve) => setImmediate(resolve));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockPurchases.isConfigured.mockResolvedValue(false);
+  mockPurchases.getAppUserID.mockResolvedValue('rc-user');
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+describe('createRevenueCatPurchaseConfig', () => {
+  it('returns platform purchase handlers and the RevenueCat delegate type', () => {
+    const config = createRevenueCatPurchaseConfig();
+
+    expect(typeof config.makePurchaseIOS).toBe('function');
+    expect(typeof config.makePurchaseAndroid).toBe('function');
+    expect(typeof config.restorePurchases).toBe('function');
+    expect(config._delegateType).toBe('h_revenuecat');
+    expect(config.makePurchase).toBeUndefined();
+    expect(config.onHeliumEvent).toBeUndefined();
+  });
+
+  it('configures RevenueCat with the provided api key when not already configured', async () => {
+    createRevenueCatPurchaseConfig({ apiKey: 'rc-key' });
+    await flushMicrotasks();
+
+    expect(mockPurchases.configure).toHaveBeenCalledWith({ apiKey: 'rc-key' });
+  });
+
+  it('ignores the provided api key when RevenueCat is already configured', async () => {
+    mockPurchases.isConfigured.mockResolvedValue(true);
+
+    createRevenueCatPurchaseConfig({ apiKey: 'rc-key' });
+    await flushMicrotasks();
+
+    expect(mockPurchases.configure).not.toHaveBeenCalled();
+  });
+
+  it('syncs the RevenueCat app user id to the native SDK', async () => {
+    createRevenueCatPurchaseConfig();
+    await flushMicrotasks();
+
+    expect(setRevenueCatAppUserId).toHaveBeenCalledWith('rc-user');
+  });
+});
+
+describe('makePurchaseIOS', () => {
+  it('purchases the product and returns transaction and product ids', async () => {
+    mockPurchases.getProducts.mockResolvedValue([product('pro_monthly')]);
+    mockPurchases.purchaseStoreProduct.mockResolvedValue(purchaseResult('pro_monthly', 'txn-1'));
+    const config = createRevenueCatPurchaseConfig();
+
+    const result = await config.makePurchaseIOS!('pro_monthly');
+
+    expect(result).toEqual({
+      status: 'purchased',
+      transactionId: 'txn-1',
+      productId: 'pro_monthly',
+    });
+  });
+
+  it('retries once after a transient store error and succeeds', async () => {
+    jest.useFakeTimers();
+    mockPurchases.getProducts.mockResolvedValue([product('pro_monthly')]);
+    mockPurchases.purchaseStoreProduct
+      .mockRejectedValueOnce(rcError(PURCHASES_ERROR_CODE.STORE_PROBLEM_ERROR))
+      .mockResolvedValueOnce(purchaseResult('pro_monthly', 'txn-2'));
+    const config = createRevenueCatPurchaseConfig();
+
+    const resultPromise = config.makePurchaseIOS!('pro_monthly');
+    await jest.runAllTimersAsync();
+    const result = await resultPromise;
+
+    expect(mockPurchases.purchaseStoreProduct).toHaveBeenCalledTimes(2);
+    expect(result.status).toBe('purchased');
+  });
+
+  it('fails after the retry when the product is never found', async () => {
+    jest.useFakeTimers();
+    mockPurchases.getProducts.mockResolvedValue([]);
+    const config = createRevenueCatPurchaseConfig();
+
+    const resultPromise = config.makePurchaseIOS!('missing_product');
+    await jest.runAllTimersAsync();
+    const result = await resultPromise;
+
+    expect(result.status).toBe('failed');
+    expect(result.error).toContain('product not found: missing_product');
+    expect(mockPurchases.purchaseStoreProduct).not.toHaveBeenCalled();
+  });
+
+  it('maps a payment pending error to pending without retrying', async () => {
+    mockPurchases.getProducts.mockResolvedValue([product('pro_monthly')]);
+    mockPurchases.purchaseStoreProduct.mockRejectedValue(
+      rcError(PURCHASES_ERROR_CODE.PAYMENT_PENDING_ERROR)
+    );
+    const config = createRevenueCatPurchaseConfig();
+
+    const result = await config.makePurchaseIOS!('pro_monthly');
+
+    expect(result.status).toBe('pending');
+    expect(mockPurchases.purchaseStoreProduct).toHaveBeenCalledTimes(1);
+  });
+
+  it('maps a cancellation to cancelled without retrying', async () => {
+    mockPurchases.getProducts.mockResolvedValue([product('pro_monthly')]);
+    mockPurchases.purchaseStoreProduct.mockRejectedValue(
+      rcError(PURCHASES_ERROR_CODE.PURCHASE_CANCELLED_ERROR)
+    );
+    const config = createRevenueCatPurchaseConfig();
+
+    const result = await config.makePurchaseIOS!('pro_monthly');
+
+    expect(result.status).toBe('cancelled');
+    expect(mockPurchases.purchaseStoreProduct).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports non-retryable errors with code and underlying message', async () => {
+    mockPurchases.getProducts.mockResolvedValue([product('pro_monthly')]);
+    mockPurchases.purchaseStoreProduct.mockRejectedValue(rcError('23', 'receipt already in use'));
+    const config = createRevenueCatPurchaseConfig();
+
+    const result = await config.makePurchaseIOS!('pro_monthly');
+
+    expect(result.status).toBe('failed');
+    expect(result.error).toContain('[RevenueCat]');
+    expect(result.error).toContain('code: 23');
+    expect(result.error).toContain('receipt already in use');
+    expect(mockPurchases.purchaseStoreProduct).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('makePurchaseAndroid', () => {
+  it('purchases the subscription option matching basePlanId:offerId', async () => {
+    const options = [{ id: 'monthly' }, { id: 'monthly:intro' }];
+    mockPurchases.getProducts.mockResolvedValue([product('pro_monthly', options)]);
+    mockPurchases.purchaseSubscriptionOption.mockResolvedValue(purchaseResult('pro_monthly'));
+    const config = createRevenueCatPurchaseConfig();
+
+    const result = await config.makePurchaseAndroid!('pro_monthly', 'monthly', 'intro');
+
+    expect(mockPurchases.purchaseSubscriptionOption).toHaveBeenCalledWith(options[1]);
+    expect(result.status).toBe('purchased');
+  });
+
+  it('purchases the subscription option matching basePlanId when no offer matches', async () => {
+    const options = [{ id: 'monthly' }, { id: 'annual' }];
+    mockPurchases.getProducts.mockResolvedValue([product('pro_monthly', options)]);
+    mockPurchases.purchaseSubscriptionOption.mockResolvedValue(purchaseResult('pro_monthly'));
+    const config = createRevenueCatPurchaseConfig();
+
+    const result = await config.makePurchaseAndroid!('pro_monthly', 'monthly');
+
+    expect(mockPurchases.purchaseSubscriptionOption).toHaveBeenCalledWith(options[0]);
+    expect(result.status).toBe('purchased');
+  });
+
+  it('purchases via product lookup when no base plan or offer is provided', async () => {
+    mockPurchases.getProducts.mockResolvedValue([product('coins_100')]);
+    mockPurchases.purchaseStoreProduct.mockResolvedValue(purchaseResult('coins_100'));
+    const config = createRevenueCatPurchaseConfig();
+
+    const result = await config.makePurchaseAndroid!('coins_100');
+
+    expect(mockPurchases.purchaseSubscriptionOption).not.toHaveBeenCalled();
+    expect(mockPurchases.purchaseStoreProduct).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({
+      status: 'purchased',
+      transactionId: undefined,
+      productId: 'coins_100',
+    });
+  });
+});
+
+describe('restorePurchases', () => {
+  it('returns true when the restored customer has an active entitlement', async () => {
+    mockPurchases.restorePurchases.mockResolvedValue(activeCustomerInfo('pro_monthly'));
+    const config = createRevenueCatPurchaseConfig();
+
+    await expect(config.restorePurchases()).resolves.toBe(true);
+  });
+
+  it('returns false when the restored customer has no active entitlements', async () => {
+    mockPurchases.restorePurchases.mockResolvedValue({
+      entitlements: { active: {} },
+    } as unknown as CustomerInfo);
+    const config = createRevenueCatPurchaseConfig();
+
+    await expect(config.restorePurchases()).resolves.toBe(false);
+  });
+
+  it('returns false when restore throws', async () => {
+    mockPurchases.restorePurchases.mockRejectedValue(new Error('network down'));
+    const config = createRevenueCatPurchaseConfig();
+
+    await expect(config.restorePurchases()).resolves.toBe(false);
+  });
+});

--- a/src/__tests__/revenuecat.test.ts
+++ b/src/__tests__/revenuecat.test.ts
@@ -143,6 +143,7 @@ describe('makePurchaseIOS', () => {
 
     expect(result.status).toBe('failed');
     expect(result.error).toContain('product not found: missing_product');
+    expect(mockPurchases.getProducts).toHaveBeenCalledTimes(2);
     expect(mockPurchases.purchaseStoreProduct).not.toHaveBeenCalled();
   });
 
@@ -200,13 +201,25 @@ describe('makePurchaseAndroid', () => {
     expect(result.status).toBe('purchased');
   });
 
-  it('purchases the subscription option matching basePlanId when no offer matches', async () => {
+  it('purchases the subscription option matching basePlanId when only a base plan is provided', async () => {
     const options = [{ id: 'monthly' }, { id: 'annual' }];
     mockPurchases.getProducts.mockResolvedValue([product('pro_monthly', options)]);
     mockPurchases.purchaseSubscriptionOption.mockResolvedValue(purchaseResult('pro_monthly'));
     const config = createRevenueCatPurchaseConfig();
 
     const result = await config.makePurchaseAndroid!('pro_monthly', 'monthly');
+
+    expect(mockPurchases.purchaseSubscriptionOption).toHaveBeenCalledWith(options[0]);
+    expect(result.status).toBe('purchased');
+  });
+
+  it('purchases the base plan option when the requested offer does not exist', async () => {
+    const options = [{ id: 'monthly' }, { id: 'monthly:intro' }];
+    mockPurchases.getProducts.mockResolvedValue([product('pro_monthly', options)]);
+    mockPurchases.purchaseSubscriptionOption.mockResolvedValue(purchaseResult('pro_monthly'));
+    const config = createRevenueCatPurchaseConfig();
+
+    const result = await config.makePurchaseAndroid!('pro_monthly', 'monthly', 'no_such_offer');
 
     expect(mockPurchases.purchaseSubscriptionOption).toHaveBeenCalledWith(options[0]);
     expect(result.status).toBe('purchased');
@@ -251,5 +264,24 @@ describe('restorePurchases', () => {
     const config = createRevenueCatPurchaseConfig();
 
     await expect(config.restorePurchases()).resolves.toBe(false);
+  });
+
+  it('waits for setup to finish before calling restore', async () => {
+    let finishConfiguredCheck!: (configured: boolean) => void;
+    mockPurchases.isConfigured.mockReturnValue(
+      new Promise((resolve) => {
+        finishConfiguredCheck = resolve;
+      })
+    );
+    mockPurchases.restorePurchases.mockResolvedValue(activeCustomerInfo('pro_monthly'));
+    const config = createRevenueCatPurchaseConfig({ apiKey: 'rc-key' });
+
+    const restorePromise = config.restorePurchases();
+    await flushMicrotasks();
+    expect(mockPurchases.restorePurchases).not.toHaveBeenCalled();
+
+    finishConfiguredCheck(false);
+    await expect(restorePromise).resolves.toBe(true);
+    expect(mockPurchases.configure).toHaveBeenCalledWith({ apiKey: 'rc-key' });
   });
 });

--- a/src/handlers/revenuecat.ts
+++ b/src/handlers/revenuecat.ts
@@ -297,6 +297,7 @@ export class RevenueCatHeliumHandler {
   }
 
   async restorePurchases(): Promise<boolean> {
+    await this.setUpPromise;
     try {
       const customerInfo = await Purchases.restorePurchases();
       return Object.keys(customerInfo.entitlements.active).length > 0;

--- a/src/handlers/revenuecat.ts
+++ b/src/handlers/revenuecat.ts
@@ -1,172 +1,320 @@
-import Purchases, {
-  PURCHASES_ERROR_CODE,
-  type PurchasesStoreProduct,
-} from 'react-native-purchases';
-import type { HeliumPurchaseConfig, HeliumPurchaseResult } from '../types';
 import type {
-  PurchasesError,
-  PurchasesPackage,
-  CustomerInfoUpdateListener,
   CustomerInfo,
   PurchasesEntitlementInfo,
+  PurchasesError,
+  PurchasesStoreProduct,
+  SubscriptionOption,
 } from 'react-native-purchases';
-import { setRevenueCatAppUserId } from '@tryheliumai/paywall-sdk-react-native';
+import Purchases, { PRODUCT_CATEGORY, PURCHASES_ERROR_CODE } from 'react-native-purchases';
+import { Platform } from 'react-native';
+import type { HeliumPurchaseConfig, HeliumPurchaseResult } from '../types';
+import { setRevenueCatAppUserId } from '../native-interface';
 
-// Rename the factory function
-export function createRevenueCatPurchaseConfig(config?: {
+export interface RevenueCatConfig {
+  /** RevenueCat API key (cross-platform). Only needed if RevenueCat is not already configured externally (e.g. via Purchases.configure). */
   apiKey?: string;
-}): HeliumPurchaseConfig {
-    const rcHandler = new RevenueCatHeliumHandler(config?.apiKey);
-    return {
-      makePurchase: rcHandler.makePurchase.bind(rcHandler),
-      restorePurchases: rcHandler.restorePurchases.bind(rcHandler),
-    };
+  /** iOS-specific RevenueCat API key. Takes precedence over `apiKey` on iOS. Only needed if RevenueCat is not already configured externally. */
+  apiKeyIOS?: string;
+  /** Android-specific RevenueCat API key. Takes precedence over `apiKey` on Android. Only needed if RevenueCat is not already configured externally. */
+  apiKeyAndroid?: string;
 }
 
+export function createRevenueCatPurchaseConfig(config?: RevenueCatConfig): HeliumPurchaseConfig {
+  const rcHandler = new RevenueCatHeliumHandler(config);
+  return {
+    makePurchaseIOS: rcHandler.makePurchaseIOS.bind(rcHandler),
+    makePurchaseAndroid: rcHandler.makePurchaseAndroid.bind(rcHandler),
+    restorePurchases: rcHandler.restorePurchases.bind(rcHandler),
+    _delegateType: 'h_revenuecat',
+  };
+}
+
+// RC error codes worth retrying. These are transient failures that may resolve on a second attempt.
+const RETRYABLE_RC_CODES = new Set([
+  PURCHASES_ERROR_CODE.STORE_PROBLEM_ERROR,
+  PURCHASES_ERROR_CODE.NETWORK_ERROR,
+  PURCHASES_ERROR_CODE.MISSING_RECEIPT_FILE_ERROR,
+  PURCHASES_ERROR_CODE.UNKNOWN_BACKEND_ERROR,
+]);
+
+type PurchaseAttemptResult = HeliumPurchaseResult & { shouldRetry?: boolean };
+
 export class RevenueCatHeliumHandler {
-    private productIdToPackageMapping: Record<string, PurchasesPackage> = {};
-    private isMappingInitialized: boolean = false;
-    private initializationPromise: Promise<void> | null = null;
+  private setUpPromise: Promise<void>;
 
-    private rcProductToPackageMapping: Record<string, PurchasesStoreProduct> = {};
-
-    constructor(apiKey?: string) {
-        if (apiKey) {
-            Purchases.configure({ apiKey });
-        }
-        void this.initializePackageMapping();
+  constructor(config?: RevenueCatConfig) {
+    // Determine which API key to use based on platform
+    let effectiveApiKey: string | undefined;
+    if (Platform.OS === 'ios' && config?.apiKeyIOS) {
+      effectiveApiKey = config.apiKeyIOS;
+    } else if (Platform.OS === 'android' && config?.apiKeyAndroid) {
+      effectiveApiKey = config.apiKeyAndroid;
+    } else {
+      effectiveApiKey = config?.apiKey;
     }
 
-    private async initializePackageMapping(): Promise<void> {
-        if (this.initializationPromise) {
-            return this.initializationPromise;
-        }
-        this.initializationPromise = (async () => {
-            try {
-                // Keep this value as up-to-date as possible
-                setRevenueCatAppUserId(await Purchases.getAppUserID());
+    this.setUpPromise = this.setUp(effectiveApiKey);
+  }
 
-                const offerings = await Purchases.getOfferings();
-                const allOfferings = offerings.all;
-                for (const offering of Object.values(allOfferings)) {
-                  offering.availablePackages.forEach((pkg: PurchasesPackage) => {
-                    if (pkg.product?.identifier) {
-                      this.productIdToPackageMapping[pkg.product.identifier] = pkg;
-                    }
-                  });
-                }
-                this.isMappingInitialized = true;
-            } catch (error) {
-                this.isMappingInitialized = false;
-            } finally {
-                 this.initializationPromise = null;
-            }
-        })();
-         return this.initializationPromise;
+  private async setUp(apiKey?: string): Promise<void> {
+    if (apiKey) {
+      try {
+        if (await Purchases.isConfigured()) {
+          console.log(
+            '[Helium] RevenueCat is already configured, ignoring provided RevenueCat api key.'
+          );
+        } else {
+          Purchases.configure({ apiKey });
+        }
+      } catch {
+        console.log('[Helium] Failed to configure RevenueCat.');
+      }
+    }
+    // Keep this value as up-to-date as possible
+    await this.syncRevenueCatAppUserId();
+  }
+
+  private async syncRevenueCatAppUserId(): Promise<void> {
+    try {
+      const id = await Purchases.getAppUserID();
+      setRevenueCatAppUserId(id);
+    } catch {
+      console.log('[Helium] Could not sync RevenueCat app user ID.');
+    }
+  }
+
+  async makePurchaseIOS(productId: string): Promise<HeliumPurchaseResult> {
+    await this.setUpPromise;
+    // Keep this value as up-to-date as possible
+    await this.syncRevenueCatAppUserId();
+    const result = await this.attemptPurchaseIOS(productId);
+
+    if (this.isRetryableResult(result)) {
+      await this.delay(1000);
+      return this.attemptPurchaseIOS(productId);
+    }
+    return result;
+  }
+
+  private async attemptPurchaseIOS(productId: string): Promise<PurchaseAttemptResult> {
+    let rcProduct: PurchasesStoreProduct | undefined;
+    try {
+      rcProduct = await this.getProduct(productId);
+    } catch {
+      return {
+        status: 'failed',
+        shouldRetry: true,
+        error: `[RevenueCat] Failed to retrieve product: ${productId}`,
+      };
     }
 
-    private async ensureMappingInitialized(): Promise<void> {
-        if (!this.isMappingInitialized && !this.initializationPromise) {
-            await this.initializePackageMapping();
-        } else if (this.initializationPromise) {
-            await this.initializationPromise;
-        }
+    if (!rcProduct) {
+      return {
+        status: 'failed',
+        shouldRetry: true,
+        error: `[RevenueCat] iOS product not found: ${productId}`,
+      };
     }
 
-    async makePurchase(productId: string): Promise<HeliumPurchaseResult> {
-        await this.ensureMappingInitialized();
-        // Keep this value as up-to-date as possible
-        setRevenueCatAppUserId(await Purchases.getAppUserID());
+    try {
+      const purchaseResult = await Purchases.purchaseStoreProduct(rcProduct);
+      const transactionId = purchaseResult.transaction?.transactionIdentifier;
+      return this.evaluatePurchaseResult(purchaseResult.customerInfo, productId, transactionId);
+    } catch (error) {
+      return this.handlePurchasesError(error);
+    }
+  }
 
-        const pkg: PurchasesPackage | undefined = this.productIdToPackageMapping[productId];
-        let rcProduct: PurchasesStoreProduct | undefined;
-        if (!pkg) {
-            // Use cached if available
-            rcProduct = this.rcProductToPackageMapping[productId];
-            if (!rcProduct) {
-                // Try to retrieve now
-                try {
-                    const rcProducts = await Purchases.getProducts([productId]);
-                    rcProduct = rcProducts.length > 0 ? rcProducts[0] : undefined;
-                } catch {
-                    // 'failed' status will be returned
-                }
-                if (rcProduct) {
-                    this.rcProductToPackageMapping[productId] = rcProduct;
-                }
-            }
-        }
+  async makePurchaseAndroid(
+    productId: string,
+    basePlanId?: string,
+    offerId?: string
+  ): Promise<HeliumPurchaseResult> {
+    await this.setUpPromise;
+    // Keep this value as up-to-date as possible
+    await this.syncRevenueCatAppUserId();
+    const result = await this.attemptPurchaseAndroid(productId, basePlanId, offerId);
 
+    if (this.isRetryableResult(result)) {
+      await this.delay(1000);
+      return this.attemptPurchaseAndroid(productId, basePlanId, offerId);
+    }
+    return result;
+  }
+
+  private async attemptPurchaseAndroid(
+    productId: string,
+    basePlanId?: string,
+    offerId?: string
+  ): Promise<PurchaseAttemptResult> {
+    // Handle subscription with base plan or offer
+    if (basePlanId || offerId) {
+      const subscriptionOption = await this.findAndroidSubscriptionOption(
+        productId,
+        basePlanId,
+        offerId
+      );
+
+      if (subscriptionOption) {
         try {
-            let customerInfo: CustomerInfo;
-            if (pkg) {
-                customerInfo = (await Purchases.purchasePackage(pkg)).customerInfo;
-            } else if (rcProduct) {
-                customerInfo = (await Purchases.purchaseStoreProduct(rcProduct)).customerInfo;
-            } else {
-                return { status: 'failed', error: `RevenueCat Product/Package not found for ID: ${productId}` };
-            }
-            const isActive = this.isProductActive(customerInfo, productId);
-            if (isActive) {
-                return { status: 'purchased' };
-            } else {
-                // This case might occur if the purchase succeeded but the entitlement wasn't immediately active
-                // or if a different product became active.
-                // Consider if polling/listening might be needed here too, similar to pending.
-                // For now, returning failed as the specific product isn't confirmed active.
-                return { status: 'failed', error: 'Purchase possibly complete but entitlement/subscription not active for this product.' };
-            }
+          const customerInfo = (await Purchases.purchaseSubscriptionOption(subscriptionOption))
+            .customerInfo;
+
+          return this.evaluatePurchaseResult(customerInfo, productId);
         } catch (error) {
-            const purchasesError = error as PurchasesError;
-
-            if (purchasesError?.code === PURCHASES_ERROR_CODE.PAYMENT_PENDING_ERROR) {
-                // Wait for a terminal state for up to 5 seconds
-                return new Promise((resolve) => {
-                    // Define the listener function separately to remove it later
-                    const updateListener: CustomerInfoUpdateListener = (updatedCustomerInfo: CustomerInfo) => {
-                        const isActive = this.isProductActive(updatedCustomerInfo, productId);
-                        if (isActive) {
-                            clearTimeout(timeoutId);
-                            // Remove listener using the function reference
-                            Purchases.removeCustomerInfoUpdateListener(updateListener);
-                            resolve({ status: 'purchased' });
-                        }
-                    };
-
-                    const timeoutId = setTimeout(() => {
-                         // Remove listener using the function reference on timeout
-                        Purchases.removeCustomerInfoUpdateListener(updateListener);
-                        resolve({ status: 'pending' });
-                    }, 5000);
-
-                    // Add the listener
-                    Purchases.addCustomerInfoUpdateListener(updateListener);
-                });
-            }
-
-            if (purchasesError?.code === PURCHASES_ERROR_CODE.PURCHASE_CANCELLED_ERROR) {
-                return { status: 'cancelled' };
-            }
-
-            // Handle other errors
-            return { status: 'failed', error: purchasesError?.message || 'RevenueCat purchase failed.' };
+          return this.handlePurchasesError(error);
         }
+      }
     }
 
-    // Helper function to check if a product is active in CustomerInfo
-    private isProductActive(customerInfo: CustomerInfo, productId: string): boolean {
-        return Object.values(customerInfo.entitlements.active).some((entitlement: PurchasesEntitlementInfo) => entitlement.productIdentifier === productId)
-               || customerInfo.activeSubscriptions.includes(productId)
-               || customerInfo.allPurchasedProductIdentifiers.includes(productId);
-    }
-
-    async restorePurchases(): Promise<boolean> {
-        try {
-            const customerInfo = await Purchases.restorePurchases();
-            const isActive = Object.keys(customerInfo.entitlements.active).length > 0;
-            return isActive;
-        } catch (error) {
-            return false;
+    // Handle one-time purchase or subscription that didn't have matching base plan / offer
+    let rcProduct: PurchasesStoreProduct | undefined;
+    try {
+      // Try non-subscription (NON_SUBSCRIPTION) product first; most likely not a sub at this point
+      let products = await Purchases.getProducts([productId], PRODUCT_CATEGORY.NON_SUBSCRIPTION);
+      if (products.length > 0) {
+        rcProduct = products[0];
+      } else {
+        // Then try subscription product (let RC pick option since we couldn't find a match)
+        products = await Purchases.getProducts([productId]);
+        if (products.length > 0) {
+          rcProduct = products[0];
         }
+      }
+    } catch {
+      return {
+        status: 'failed',
+        shouldRetry: true,
+        error: `[RevenueCat] Failed to retrieve Android product: ${productId}`,
+      };
     }
+    if (!rcProduct) {
+      return {
+        status: 'failed',
+        shouldRetry: true,
+        error: `[RevenueCat] Android product not found: ${productId}`,
+      };
+    }
+
+    try {
+      const customerInfo = (await Purchases.purchaseStoreProduct(rcProduct)).customerInfo;
+
+      return this.evaluatePurchaseResult(customerInfo, productId);
+    } catch (error) {
+      return this.handlePurchasesError(error);
+    }
+  }
+
+  // Android helper: Find subscription option
+  private async findAndroidSubscriptionOption(
+    productId: string,
+    basePlanId?: string,
+    offerId?: string
+  ): Promise<SubscriptionOption | undefined> {
+    try {
+      const products = await Purchases.getProducts([productId]);
+      if (products.length === 0) {
+        return undefined;
+      }
+
+      // RC will return multiple products if multiple base plans per subscription
+      // Collect all subscription options from all products into a flat list
+      const allSubscriptionOptions = products.flatMap(
+        (product) => product.subscriptionOptions ?? []
+      );
+
+      if (allSubscriptionOptions.length === 0) {
+        return undefined;
+      }
+
+      let subscriptionOption: SubscriptionOption | undefined;
+
+      if (offerId && basePlanId) {
+        // Look for specific offer: "basePlanId:offerId"
+        const targetId = `${basePlanId}:${offerId}`;
+        subscriptionOption = allSubscriptionOptions.find((opt) => opt.id === targetId);
+      }
+      if (!subscriptionOption && basePlanId) {
+        // Otherwise the RC option id will simply be base plan id
+        subscriptionOption = allSubscriptionOptions.find((opt) => opt.id === basePlanId);
+      }
+
+      return subscriptionOption;
+    } catch {
+      return undefined;
+    }
+  }
+
+  // Helper function to check if a product is active in CustomerInfo
+  private isProductActive(customerInfo: CustomerInfo, productId: string): boolean {
+    return (
+      Object.values(customerInfo.entitlements.active).some(
+        (entitlement: PurchasesEntitlementInfo) => entitlement.productIdentifier === productId
+      ) ||
+      customerInfo.activeSubscriptions.includes(productId) ||
+      customerInfo.allPurchasedProductIdentifiers.includes(productId)
+    );
+  }
+
+  // Helper function to process purchase result
+  private evaluatePurchaseResult(
+    customerInfo: CustomerInfo,
+    productId: string,
+    transactionId?: string
+  ): HeliumPurchaseResult {
+    if (!this.isProductActive(customerInfo, productId)) {
+      console.log(
+        '[Helium] Purchase succeeded but product not immediately active in customerInfo:',
+        productId
+      );
+    }
+
+    return { status: 'purchased', transactionId, productId };
+  }
+
+  // Helper function to handle RevenueCat purchase errors
+  private handlePurchasesError(error: unknown): PurchaseAttemptResult {
+    const purchasesError = error as PurchasesError;
+
+    if (purchasesError?.code === PURCHASES_ERROR_CODE.PAYMENT_PENDING_ERROR) {
+      return { status: 'pending' };
+    }
+
+    if (purchasesError?.code === PURCHASES_ERROR_CODE.PURCHASE_CANCELLED_ERROR) {
+      return { status: 'cancelled' };
+    }
+
+    const errorDesc = purchasesError?.message || 'purchase failed.';
+    const underlying = purchasesError?.underlyingErrorMessage;
+    const errorMsg = underlying
+      ? `[RevenueCat] ${errorDesc} code: ${purchasesError?.code} | ${underlying}`
+      : `[RevenueCat] ${errorDesc} code: ${purchasesError?.code}`;
+    return {
+      status: 'failed',
+      shouldRetry: RETRYABLE_RC_CODES.has(purchasesError?.code),
+      error: errorMsg,
+    };
+  }
+
+  async restorePurchases(): Promise<boolean> {
+    try {
+      const customerInfo = await Purchases.restorePurchases();
+      return Object.keys(customerInfo.entitlements.active).length > 0;
+    } catch {
+      return false;
+    }
+  }
+
+  private async getProduct(productId: string): Promise<PurchasesStoreProduct | undefined> {
+    const products = await Purchases.getProducts([productId]);
+    return products.length > 0 ? products[0] : undefined;
+  }
+
+  private isRetryableResult(result: PurchaseAttemptResult): boolean {
+    return result.status === 'failed' && !!result.shouldRetry;
+  }
+
+  private delay(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
 }

--- a/src/revenuecat.ts
+++ b/src/revenuecat.ts
@@ -1,1 +1,2 @@
 export { createRevenueCatPurchaseConfig } from './handlers/revenuecat';
+export type { RevenueCatConfig } from './handlers/revenuecat';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2386,26 +2386,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@revenuecat/purchases-js-hybrid-mappings@npm:17.21.0":
-  version: 17.21.0
-  resolution: "@revenuecat/purchases-js-hybrid-mappings@npm:17.21.0"
+"@revenuecat/purchases-js-hybrid-mappings@npm:18.21.0":
+  version: 18.21.0
+  resolution: "@revenuecat/purchases-js-hybrid-mappings@npm:18.21.0"
   dependencies:
-    "@revenuecat/purchases-js": 1.18.3
-  checksum: 0d782a13d91aa8c9a2594853c38696f8074e55c7266ebd6878813f51b3964f139c1910e0984ef36af80087b6232c2b0e6188a1397b3ffc22ea3fe5ea45dc2dea
+    "@revenuecat/purchases-js": 1.47.1
+  checksum: fea27261e36ff3fda20a0cd6482b2701c0d93547b41403ea8466645fa64d555b32aac08041986ca351e2df96fa2c4ecffb35606c9884b022aa90bf017b4a62fd
   languageName: node
   linkType: hard
 
-"@revenuecat/purchases-js@npm:1.18.3":
-  version: 1.18.3
-  resolution: "@revenuecat/purchases-js@npm:1.18.3"
-  checksum: e357f9a559b1ba030ff51a84c95745995ef2c7e1d3556d582278b1afe55268be7bd6f4f7e5529ed8513d8d435f759cdf95564276d0e1219256c7cc0839342f64
+"@revenuecat/purchases-js@npm:1.47.1":
+  version: 1.47.1
+  resolution: "@revenuecat/purchases-js@npm:1.47.1"
+  checksum: 202d78daa1deaf5546a689eac2df05a87b30e99c699f4049c8d0322a1ad9b29d5a19c908e405f65aa4bffa9deb0057574fb6df5a5fba096d8d030da67375dca9
   languageName: node
   linkType: hard
 
-"@revenuecat/purchases-typescript-internal@npm:17.21.0":
-  version: 17.21.0
-  resolution: "@revenuecat/purchases-typescript-internal@npm:17.21.0"
-  checksum: d2fb92e4a70a4145f3759c2b2822542645f7e0f4e0578c3450e21db70cc39088a7fc3d7d96d8dbd3ad35d832f32f4e8ae6ea7487c00c3fa11a8a592d3d3cb3d2
+"@revenuecat/purchases-typescript-internal@npm:18.21.0":
+  version: 18.21.0
+  resolution: "@revenuecat/purchases-typescript-internal@npm:18.21.0"
+  checksum: 853c716fbd7e6f1aae0ed315894ba172db2b288ba157bf0bf10641473ba392083d1fdfee8fa2f6727cc355b7a538075088acee6bb078c01f7b58e7cea67a3ff3
   languageName: node
   linkType: hard
 
@@ -2473,14 +2473,14 @@ __metadata:
     react: 18.2.0
     react-native: 0.71.7
     react-native-builder-bob: ^0.37.0
-    react-native-purchases: ">=5.1.0"
+    react-native-purchases: ">=8.0.0"
     turbo: ^1.10.7
     typescript: ^5.2.2
   peerDependencies:
     expo-file-system: "*"
     react: ">=18.2.0"
     react-native: ">=0.71.7"
-    react-native-purchases: ">=5.1.0"
+    react-native-purchases: ">=8.0.0"
   peerDependenciesMeta:
     expo-file-system:
       optional: true
@@ -8976,12 +8976,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-purchases@npm:>=5.1.0":
-  version: 9.6.8
-  resolution: "react-native-purchases@npm:9.6.8"
+"react-native-purchases@npm:>=8.0.0":
+  version: 10.4.3
+  resolution: "react-native-purchases@npm:10.4.3"
   dependencies:
-    "@revenuecat/purchases-js-hybrid-mappings": 17.21.0
-    "@revenuecat/purchases-typescript-internal": 17.21.0
+    "@revenuecat/purchases-js-hybrid-mappings": 18.21.0
+    "@revenuecat/purchases-typescript-internal": 18.21.0
   peerDependencies:
     react: ">= 16.6.3"
     react-native: ">= 0.73.0"
@@ -8989,7 +8989,7 @@ __metadata:
   peerDependenciesMeta:
     react-native-web:
       optional: true
-  checksum: c3dff7bfb847b4fb4fcc8850c4e4999dd300362e5e73088c226fca1462a1ea6cf755f8ced62b614d428482634a2e7e7bba8bd0089a417be9e771f6e8b3fa32b8
+  checksum: 99ccfe74abd3e8dab3bb66bc09a250ef28483cfd18cb795e948dd5885620e79a222083be86bcfd12632a5fbb8c0e49a28535a7002855bf01840b46850f62f641
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Bumped the `react-native-purchases` to `>=8.0.0` because the ported handler depends on APIs that don't exist in older releases (notably `PRODUCT_CATEGORY` and `purchaseSubscriptionOption` from v6, and `MakePurchaseResult.transaction` from v8)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Rewrites in-app purchase and restore behavior and drops the legacy `makePurchase` API, with a major `react-native-purchases` version bump affecting payment flows on iOS and Android.
> 
> **Overview**
> **RevenueCat integration is reworked** to align with Helium’s platform-specific purchase contract and newer RevenueCat SDK APIs. The `react-native-purchases` peer/dev requirement moves from **>=5.1.0** to **>=8.0.0**.
> 
> `createRevenueCatPurchaseConfig` now exposes **`makePurchaseIOS`**, **`makePurchaseAndroid`**, and **`restorePurchases`** with **`_delegateType: 'h_revenuecat'`** instead of a single **`makePurchase`**. Config supports **`apiKey`**, **`apiKeyIOS`**, and **`apiKeyAndroid`**; setup calls **`Purchases.isConfigured()`** and skips **`configure`** when RevenueCat is already initialized, then syncs the app user ID via **`setRevenueCatAppUserId`**.
> 
> Purchases no longer go through offerings/package mapping. **iOS** loads products with **`getProducts`** and buys with **`purchaseStoreProduct`**, returning **`transactionId`** and **`productId`**. **Android** selects subscription options by **`basePlanId`** / **`offerId`** (including **`basePlanId:offerId`**), uses **`purchaseSubscriptionOption`**, and falls back to **`PRODUCT_CATEGORY.NON_SUBSCRIPTION`** / store product purchase when plans aren’t specified. Transient RC errors and missing products trigger a **single retry** after 1s; pending/cancelled map directly without the old customer-info listener wait. Successful purchases return **`purchased`** even if entitlements aren’t immediately active (logged only).
> 
> Adds **`src/__tests__/revenuecat.test.ts`** and exports **`RevenueCatConfig`** from **`src/revenuecat.ts`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87f30a85e29e8b74f5034dd9d9e5b338cdf095f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added platform-specific RevenueCat purchase flows for iOS and Android.
  * Added support for separate iOS and Android API keys.
  * Added Android subscription selection by base plan and offer.
  * Added automatic retry for certain temporary purchase failures.
  * Improved handling of pending, cancelled, failed, and restored purchases.

* **Bug Fixes**
  * Purchase setup now avoids reconfiguring an already configured RevenueCat SDK.

* **Chores**
  * Updated the supported `react-native-purchases` version to 8.0.0 or later.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->