### PR TITLE
[HEL-6265] | Update native Helium SDKs to iOS 4.5.5 and Android 4.4.7

### DIFF
--- a/PaywallSdkReactNative.podspec
+++ b/PaywallSdkReactNative.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
 
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
-  s.dependency 'Helium', '4.3.0'
+  s.dependency 'Helium', '4.5.5'
 
   # Use install_modules_dependencies helper to install the dependencies if React Native version >=0.71.0.
   # See https://github.com/facebook/react-native/blob/febf6b7f33fdb4904669f99d795eba4c0f95d7bf/scripts/cocoapods/new_architecture.rb#L79.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -84,7 +84,7 @@ def kotlin_version = getExtOrDefault("kotlinVersion")
 dependencies {
   implementation "com.facebook.react:react-android"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation("com.tryhelium.paywall:core:4.4.0")
+  implementation("com.tryhelium.paywall:core:4.4.7")
   implementation "com.google.code.gson:gson:2.10.1"
   implementation("com.android.billingclient:billing:8.0.0")
 }


### PR DESCRIPTION
Updates the native Helium SDK pins to the latest releases:

- **iOS**: `Helium` pod `4.3.0` → `4.5.5` (latest, released Jul 15)
- **Android**: `com.tryhelium.paywall:core` `4.4.0` → `4.4.7` (latest, released Jun 23)

The Android bump is a drop-in, no bridge code changes needed (verified: `HeliumBridge.kt` compiles clean against 4.4.7 via the example app's gradle build). Jest suite (incl. the new RevenueCat tests from #89), typecheck, and `bob build` all pass.

`package.json` version intentionally stays at `3.0.23` — the release workflow auto-publishes on version change, and the version will be bumped in the final release PR for HEL-6265.

Supersedes the bot's `update-ios-sdk-4.5.5` branch (and the stale `update-ios-sdk-4.4.x` ones, which can be closed after merge).

Part of [HEL-6265](https://linear.app/tryhelium/issue/HEL-6265/update-old-expo-sdk-to-latest-native-iosandroid).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency version bumps only; no application logic, auth, or bridge changes in the diff.
> 
> **Overview**
> Bumps the **native Helium SDK pins** consumed by this React Native wrapper—no JS bridge or API changes in this diff.
> 
> On **iOS**, the CocoaPods dependency `Helium` moves from **4.3.0** to **4.5.5** in `PaywallSdkReactNative.podspec`. On **Android**, `com.tryhelium.paywall:core` moves from **4.4.0** to **4.4.7** in `android/build.gradle`.
> 
> The npm package version is unchanged in this PR (stays at 3.0.23) so publish-on-bump workflows do not fire until a separate release PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12f51a96e7265fe045c65d2454350d5aa9d65d86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the iOS Helium SDK to version 4.5.5.
  * Updated the Android Helium Paywall SDK to version 4.4.7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->