### PR TITLE
[HEL-6265] | Guard paywall event handlers and remove dead initializeStart event type

### DIFF
--- a/src/native-interface.tsx
+++ b/src/native-interface.tsx
@@ -231,71 +231,81 @@ export const presentUpsell = ({
 
 function callPaywallEventHandlers(event: HeliumPaywallEvent) {
   if (paywallEventHandlers) {
-    switch (event.type) {
-      case 'paywallOpen':
-        paywallEventHandlers?.onOpen?.({
-          type: 'paywallOpen',
-          triggerName: event.triggerName ?? 'unknown',
-          paywallName: event.paywallName ?? 'unknown',
-          paywallUnavailableReason: event.paywallUnavailableReason,
-          isSecondTry: event.isSecondTry ?? false,
-          loadTimeTakenMS: event.loadTimeTakenMS,
-          loadingBudgetMS: event.loadingBudgetMS,
-          viewType: 'presented',
-        });
-        break;
-      case 'paywallClose':
-        paywallEventHandlers?.onClose?.({
-          type: 'paywallClose',
-          triggerName: event.triggerName ?? 'unknown',
-          paywallName: event.paywallName ?? 'unknown',
-          isSecondTry: event.isSecondTry ?? false,
-        });
-        break;
-      case 'paywallDismissed':
-        paywallEventHandlers?.onDismissed?.({
-          type: 'paywallDismissed',
-          triggerName: event.triggerName ?? 'unknown',
-          paywallName: event.paywallName ?? 'unknown',
-          isSecondTry: event.isSecondTry ?? false,
-        });
-        break;
-      case 'purchaseSucceeded':
-        paywallEventHandlers?.onPurchaseSucceeded?.({
-          type: 'purchaseSucceeded',
-          productId: event.productId ?? 'unknown',
-          triggerName: event.triggerName ?? 'unknown',
-          paywallName: event.paywallName ?? 'unknown',
-          isSecondTry: event.isSecondTry ?? false,
-          paymentProcessor: event.paymentProcessor,
-        });
-        break;
-      case 'paywallOpenFailed':
-        paywallEventHandlers?.onOpenFailed?.({
-          type: 'paywallOpenFailed',
-          triggerName: event.triggerName ?? 'unknown',
-          paywallName: event.paywallName ?? 'unknown',
-          error: event.error ?? 'Unknown error',
-          paywallUnavailableReason: event.paywallUnavailableReason,
-          isSecondTry: event.isSecondTry ?? false,
-          loadTimeTakenMS: event.loadTimeTakenMS,
-          loadingBudgetMS: event.loadingBudgetMS,
-        });
-        break;
-      case 'customPaywallAction':
-        paywallEventHandlers?.onCustomPaywallAction?.({
-          type: 'customPaywallAction',
-          triggerName: event.triggerName ?? 'unknown',
-          paywallName: event.paywallName ?? 'unknown',
-          actionName: event.customPaywallActionName ?? 'unknown',
-          params: event.customPaywallActionParams ?? {},
-          isSecondTry: event.isSecondTry ?? false,
-        });
-        break;
+    try {
+      dispatchTypedPaywallEventHandler(event);
+    } catch (e) {
+      console.error('[Helium] paywall event handler threw', e);
     }
     try {
       paywallEventHandlers?.onAnyEvent?.(event);
-    } catch {}
+    } catch (e) {
+      console.error('[Helium] onAnyEvent handler threw', e);
+    }
+  }
+}
+
+function dispatchTypedPaywallEventHandler(event: HeliumPaywallEvent) {
+  switch (event.type) {
+    case 'paywallOpen':
+      paywallEventHandlers?.onOpen?.({
+        type: 'paywallOpen',
+        triggerName: event.triggerName ?? 'unknown',
+        paywallName: event.paywallName ?? 'unknown',
+        paywallUnavailableReason: event.paywallUnavailableReason,
+        isSecondTry: event.isSecondTry ?? false,
+        loadTimeTakenMS: event.loadTimeTakenMS,
+        loadingBudgetMS: event.loadingBudgetMS,
+        viewType: 'presented',
+      });
+      break;
+    case 'paywallClose':
+      paywallEventHandlers?.onClose?.({
+        type: 'paywallClose',
+        triggerName: event.triggerName ?? 'unknown',
+        paywallName: event.paywallName ?? 'unknown',
+        isSecondTry: event.isSecondTry ?? false,
+      });
+      break;
+    case 'paywallDismissed':
+      paywallEventHandlers?.onDismissed?.({
+        type: 'paywallDismissed',
+        triggerName: event.triggerName ?? 'unknown',
+        paywallName: event.paywallName ?? 'unknown',
+        isSecondTry: event.isSecondTry ?? false,
+      });
+      break;
+    case 'purchaseSucceeded':
+      paywallEventHandlers?.onPurchaseSucceeded?.({
+        type: 'purchaseSucceeded',
+        productId: event.productId ?? 'unknown',
+        triggerName: event.triggerName ?? 'unknown',
+        paywallName: event.paywallName ?? 'unknown',
+        isSecondTry: event.isSecondTry ?? false,
+        paymentProcessor: event.paymentProcessor,
+      });
+      break;
+    case 'paywallOpenFailed':
+      paywallEventHandlers?.onOpenFailed?.({
+        type: 'paywallOpenFailed',
+        triggerName: event.triggerName ?? 'unknown',
+        paywallName: event.paywallName ?? 'unknown',
+        error: event.error ?? 'Unknown error',
+        paywallUnavailableReason: event.paywallUnavailableReason,
+        isSecondTry: event.isSecondTry ?? false,
+        loadTimeTakenMS: event.loadTimeTakenMS,
+        loadingBudgetMS: event.loadingBudgetMS,
+      });
+      break;
+    case 'customPaywallAction':
+      paywallEventHandlers?.onCustomPaywallAction?.({
+        type: 'customPaywallAction',
+        triggerName: event.triggerName ?? 'unknown',
+        paywallName: event.paywallName ?? 'unknown',
+        actionName: event.customPaywallActionName ?? 'unknown',
+        params: event.customPaywallActionParams ?? {},
+        isSecondTry: event.isSecondTry ?? false,
+      });
+      break;
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -186,7 +186,6 @@ export type HeliumPaywallEvent = {
     | 'purchaseRestored'
     | 'purchaseRestoreFailed'
     | 'purchasePending'
-    | 'initializeStart'
     | 'initializeCalled'
     | 'paywallsDownloadSuccess'
     | 'paywallsDownloadError'


### PR DESCRIPTION
Follow-ups from review feedback on #91.

### Wrap paywall event handlers in try/catch

Only `onAnyEvent` was guarded before, so if a host app's `onOpen`/`onClose`/etc callback threw, the error propagated up through the native event emitter. Moved the switch into a helper and wrapped both dispatch paths in try/catch with a console.error. A throwing typed handler no longer prevents `onAnyEvent` from firing.

### Remove `initializeStart` from the event union

Dead type. The native SDKs on our current pins (iOS 4.5.5 / Android 4.4.7) emit `initializeCalled`, and expo-helium doesn't declare `initializeStart` either. Grepped both native repos to be sure: every `initializeStart` hit is the internal `initializeStartTime` timing param, not an event. 

### Testing

jest 47/47, tsc, lint. Also ran the example app on a device and went through several present/dismiss cycles on the new dispatch path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor preserves dispatch behavior while improving error isolation; type removal only affects a non-emitted event literal.
> 
> **Overview**
> Paywall **present** callbacks (`onOpen`, `onClose`, etc.) are now isolated from the native emitter: typed dispatch moved to `dispatchTypedPaywallEventHandler`, and both that path and `onAnyEvent` run inside **try/catch** with `[Helium]` **console.error** logging. A throwing typed handler no longer blocks `onAnyEvent`.
> 
> The `HeliumPaywallEvent` union drops **`initializeStart`** as an unused event name (native SDKs emit `initializeCalled` instead).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91eb5ebf66d5b729dbef9614a14eeaec6482bc11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->