### PR TITLE
Bump to 3.1.5 so a release carries both native SDK updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryheliumai/paywall-sdk-react-native",
-  "version": "3.1.4",
+  "version": "3.1.5",
   "description": "Paywall SDK Helium",
   "source": "./src/index.ts",
   "main": "./lib/commonjs/index.js",


### PR DESCRIPTION
Release 3.1.4 was tagged at the iOS-only merge — the Android bump landed seconds after the release snapshot, and since it didn't change `package.json` again, no release fired for it. The published 3.1.4 ships Helium iOS 4.7.0 with Android still 4.4.9.

Main already carries the correct pair (iOS 4.7.0 + Android 4.5.0); this bumps the version so merging cuts a 3.1.5 that actually contains both.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-metadata-only version bump with no runtime or dependency changes in the PR diff.
> 
> **Overview**
> **Only change:** `package.json` version **3.1.4 → 3.1.5**. No code, native dependency pins, or build config changes in this diff.
> 
> Published **3.1.4** was cut right after the iOS native bump; the Android Helium update landed afterward without another version bump, so that release shipped iOS **4.7.0** with Android still on **4.4.9**. Main already pins iOS **4.7.0** and Android **4.5.0**; merging this triggers **3.1.5** so consumers get both native versions in one published package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a968172b03169a79c62c417d7b807f4c0769d1a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package to version 3.1.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->